### PR TITLE
NS_ERROR_CONNECTION_REFUSED fix

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -6,3 +6,4 @@ CACHE_VIEWS=false
 DB_CONNECTION=sqlite
 NODE_ENV=test
 DRIVE_DISK=local
+HOST=127.0.0.1


### PR DESCRIPTION
playwright should now be able to connect to the headless browser and execute the tests in windows, fixing #7 
