### PR TITLE
chore: remove manual rtx cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Check cache
-        uses: actions/cache@v3
-        id: cache
-        with:
-          path: ~/.local/share/rtx
-          key: rtx-tools-${{ hashFiles('.tool-versions') }}
-          restore-keys: rtx-tools-
-
       - name: Setup tool versions
-        uses: jdxcode/rtx-action@v1
+        uses: jdxcode/rtx-action@801b2f548ddd13a0980fa6b199d1f4fe8e46510c
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -67,16 +59,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Check cache
-        uses: actions/cache@v3
-        id: cache
-        with:
-          path: ~/.local/share/rtx
-          key: rtx-tools-${{ hashFiles('.tool-versions') }}
-          restore-keys: rtx-tools-
-
       - name: Setup tool versions
-        uses: jdxcode/rtx-action@v1
+        uses: jdxcode/rtx-action@801b2f548ddd13a0980fa6b199d1f4fe8e46510c
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -104,16 +88,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Check cache
-        uses: actions/cache@v3
-        id: cache
-        with:
-          path: ~/.local/share/rtx
-          key: rtx-tools-${{ hashFiles('.tool-versions') }}
-          restore-keys: rtx-tools-
-
       - name: Setup tool versions
-        uses: jdxcode/rtx-action@v1
+        uses: jdxcode/rtx-action@801b2f548ddd13a0980fa6b199d1f4fe8e46510c
 
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,10 @@
     "cypress"
   ],
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "commonjs",
     "lib": [
-      "ES2020"
+      "ES2022"
     ],
     "noUnusedLocals": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Now that the rtx-action supports caching (https://github.com/jdxcode/rtx-action/commit/801b2f548ddd13a0980fa6b199d1f4fe8e46510c), the manual usage of the `actions/cache` step should no longer be needed. 